### PR TITLE
Verifying if the requester field is present when required

### DIFF
--- a/app.js
+++ b/app.js
@@ -159,7 +159,8 @@
       // field is present and is empty
       if (this.ticketFields(field) &&
           (_.isEmpty(value) || value == '-' ||
-           (field == "type" && value == "ticket"))) {
+            (field == "type" && value == "ticket") ||
+              (field == "requester" && _.isEmpty(value.email)))) {
         return false;
       }
 


### PR DESCRIPTION
on the documentation we say that the requester field can be used, but it doesn't pass the validation (fieldIsValid function) since it's not null.